### PR TITLE
Fix confusing a method name

### DIFF
--- a/server/services/content.js
+++ b/server/services/content.js
@@ -18,9 +18,9 @@ function buildContent(item, siteUrl) {
       });
       item.tags = tags;
       item.fullUrl = siteUrl + item.permalink;
-      serverUtils.toMarkdown(item.body).then(function(content){
+      serverUtils.md2html(item.body).then(function(content){
         item.excerpt = serverUtils.excerpt(content);
-        serverUtils.toMarkdown(item.body).then(function(bodyContent){
+        serverUtils.md2html(item.body).then(function(bodyContent){
           item.content = bodyContent;
           delete item.body;
           resolve(item);

--- a/server/services/rss.js
+++ b/server/services/rss.js
@@ -36,7 +36,7 @@ var rssService = {
             author: post.author,
           };
           itemsArray.push(item);
-          promiseArray.push(serverUtils.toMarkdown(post.body));
+          promiseArray.push(serverUtils.md2html(post.body));
         });
         Promise.all(promiseArray).then(function(data) {
           data.forEach(function(content, index){

--- a/server/utils.js
+++ b/server/utils.js
@@ -32,7 +32,7 @@ module.exports = {
     res.write('<!doctype>' + html);
     res.end();
   },
-  toMarkdown: function(md){
+  md2html: function(md){
     return new Promise(function(resolve, reject) {
       marked(md, function (err, content) {
         if (err) {


### PR DESCRIPTION
toMarkdown method is to transform markdown to html .
But, the name is imagined transforming something to markdown.

I think md2html is explicitly than this.
