### PR TITLE
Fix DOCTYPE

### DIFF
--- a/server/utils.js
+++ b/server/utils.js
@@ -29,7 +29,7 @@ module.exports = {
     res.set({
       'content-type': 'text/html; charset=utf-8'
     });
-    res.write('<!doctype>' + html);
+    res.write('<!DOCTYPE html>' + html);
     res.end();
   },
   md2html: function(md){


### PR DESCRIPTION
By [html spec](https://html.spec.whatwg.org/multipage/syntax.html#the-doctype), the doctype must be `<!DOCTYPE html>`.

The spec says the doctype is a case-insensitively. But I think that it's better to follow the notation in the spec.
